### PR TITLE
feat: add domain-model-generate skill for DDD

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,6 +29,9 @@ A collection of skills for Information Architecture tasks, designed to help with
 - **[document-tree-generate](skills/document-tree-generate/SKILL.md)**
   Transform lengthy documents into a semantic tree structure. Optimized for context-aware Retrieval-Augmented Generation (RAG) and LLM usage.
 
+- **[domain-model-generate](skills/domain-model-generate/SKILL.md)**
+  Generate Domain-Driven Design (DDD) models. Defines ubiquitous language, bounded contexts, aggregates, and entities.
+
 - **[metadata-schema-design](skills/metadata-schema-design/SKILL.md)**
   Design comprehensive metadata frameworks. Develops structured metadata templates and tagging systems.
 
@@ -52,7 +55,7 @@ A collection of skills for Information Architecture tasks, designed to help with
 This extension provides a suite of Information Architecture tools designed to help you analyze, organize, and structure content effectively.
 
 - **Content Strategy**: Analyze content gaps, audit quality, inventory assets, and generate card sorting materials.
-- **Structural Design**: Generate sitemaps, user flows, and design metadata schemas.
+- **Structural Design**: Generate sitemaps, user flows, design metadata schemas, and create domain models.
 - **Classification & Semantics**: Develop taxonomies, thesauri, and formal ontologies.
 - **Structured Data**: Generate semantic web markup and JSON-LD for documents.
 
@@ -65,6 +68,7 @@ This extension provides a suite of Information Architecture tools designed to he
 | `/ia:inventory` | Systematic cataloging of information assets. | [content-inventory](skills/content-inventory/SKILL.md) |
 | `/ia:card-sort` | Generate materials for card sorting studies. Creates detailed lists of content items (cards) for user research. | [card-sorting-generate](skills/card-sorting-generate/SKILL.md) |
 | `/ia:doc-tree` | Transform lengthy documents into a semantic tree structure optimized for LLMs. | [document-tree-generate](skills/document-tree-generate/SKILL.md) |
+| `/ia:domain-model` | Generate Domain-Driven Design (DDD) models. | [domain-model-generate](skills/domain-model-generate/SKILL.md) |
 | `/ia:metadata` | Design comprehensive metadata frameworks. | [metadata-schema-design](skills/metadata-schema-design/SKILL.md) |
 | `/ia:ontology` | Design formal ontologies using OWL/RDFS. Defines classes, properties, and relationships. | [ontology-define](skills/ontology-define/SKILL.md) |
 | `/ia:sitemap` | Generate hierarchical site structure and navigation maps. | [sitemap-generate](skills/sitemap-generate/SKILL.md) |

--- a/skills/domain-model-generate/SKILL.md
+++ b/skills/domain-model-generate/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: domain-model-generate
+description: Generate Domain-Driven Design (DDD) models. Defines ubiquitous language, bounded contexts, aggregates, entities, and value objects.
+required_roles:
+  scribe: roles/scribe.editor
+personas: [software-architect, systems-analyst, product-manager]
+---
+
+# Domain Model Generate Skill
+
+Create a Domain-Driven Design (DDD) model to structure software complexity based on the underlying business domain. This skill establishes the foundation for software architecture by mapping out the conceptual domain, defining clear boundaries, and establishing a common vocabulary.
+
+## Inputs
+
+- `DOMAIN_DESCRIPTION` - Detailed description of the business domain, requirements, or problem space (e.g., "E-commerce order fulfillment system" or a link to a requirements document).
+- `FORMAT` - (Optional) Output format: "markdown", "mermaid", "json" (default: "markdown").
+- `FOCUS_AREA` - (Optional) Specific bounded context or process to focus on if the domain is exceptionally large.
+
+## Workflow
+
+### Step 1: Ubiquitous Language Definition
+
+Analyze the `DOMAIN_DESCRIPTION` to extract the common language used by domain experts.
+- Identify core concepts, actions, and rules.
+- Create a glossary of terms to ensure consistent communication across technical and non-technical teams.
+
+### Step 2: Bounded Context Identification
+
+Divide the overarching domain into distinct semantic boundaries.
+- Define specific sub-domains (e.g., Billing, Shipping, Inventory).
+- Clarify the context map, detailing how different bounded contexts interact and share information.
+
+### Step 3: Structural Modeling
+
+Within each Bounded Context, identify the building blocks:
+- **Aggregates**: Clusters of domain objects that can be treated as a single unit (e.g., an Order and its Line Items).
+- **Entities**: Objects defined by a thread of continuity and identity (e.g., a Customer with a unique ID).
+- **Value Objects**: Objects that describe characteristics but have no conceptual identity (e.g., an Address or a Money amount).
+
+### Step 4: Behavioral Modeling (Domain Events)
+
+Identify significant occurrences within the domain.
+- Define **Domain Events** (e.g., `OrderPlaced`, `PaymentSucceeded`) that trigger subsequent processes or inform other bounded contexts.
+
+### Step 5: Output Generation
+
+Synthesize the defined concepts into the requested `FORMAT`.
+- Organize the output clearly, ensuring the relationship between the Ubiquitous Language, Bounded Contexts, and Structural Models is evident.
+
+## Required Outputs
+
+A comprehensive domain model document in the requested `FORMAT`.
+
+**Example (Markdown excerpt):**
+
+```markdown
+# Domain Model: E-commerce Fulfillment
+
+## Ubiquitous Language
+- **Order**: A customer's request to purchase goods.
+- **Fulfillment Center**: A location where inventory is stored and orders are packed.
+
+## Bounded Contexts
+### 1. Order Management Context
+- **Aggregate Root**: `Order` (Entity)
+  - Contains: `OrderLineItem` (Entity)
+  - References: `ShippingAddress` (Value Object)
+- **Domain Events**: `OrderCreated`, `OrderCancelled`
+
+### 2. Inventory Context
+- **Aggregate Root**: `ProductInventory` (Entity)
+- **Domain Events**: `StockReserved`, `StockDepleted`
+```
+
+## Quick Reference
+
+- **Purpose**: Align software design with business realities and manage complexity.
+- **Key Concepts**: Ubiquitous Language, Bounded Context, Aggregate, Entity, Value Object, Domain Event.
+- **When to Use**: During system design, when refactoring legacy code, or when onboarding teams to a complex business domain.

--- a/skills/domain-model-generate/command.toml
+++ b/skills/domain-model-generate/command.toml
@@ -1,0 +1,2 @@
+command = "/ia:domain-model"
+description = "Generate Domain-Driven Design (DDD) models. Defines ubiquitous language, bounded contexts, aggregates, entities, and value objects."


### PR DESCRIPTION
Add a new `domain-model-generate` skill to help generate Domain-Driven Design (DDD) models.

- Creates `skills/domain-model-generate/SKILL.md` outlining workflow and inputs for domain modeling (Ubiquitous Language, Bounded Contexts, Aggregates).
- Creates `skills/domain-model-generate/command.toml` registering the `/ia:domain-model` command.
- Updates `GEMINI.md` to list the new skill and command in the Information Architecture section.

---
*PR created automatically by Jules for task [11370970941361728436](https://jules.google.com/task/11370970941361728436) started by @dandye*